### PR TITLE
use environment variables in config.php, add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:cli-alpine3.16
+ARG RIGCTL_HOST
+WORKDIR /app
+COPY *.php ./
+CMD ["php", "/app/rigctlCloudlogInterface.php"]

--- a/README.md
+++ b/README.md
@@ -31,3 +31,30 @@ If you want to run it in the background without an open terminal window, you can
 If you prefer tmux, use `tmux new -s rigctlCloudlog ./rigctlCloudlogInterface.php`. 
 
 For more information on how-to setup hamlib/rigctld have a look over at the excellent guide written for pat: https://github.com/la5nta/pat/wiki/Rig-control
+
+## Environment Variables
+By default, `config.php` will look for the following environment variables:
+
+- `RIGCTL_HOST`: Host name or IP address for rigctl
+- `RIGCTL_PORT`: Port number for rigctl
+- `CLOUDLOG_URL`: Your cloudlog instance URL
+- `CLOUDLOG_KEY`: Cloudlog API key
+- `CLOUDLOG_KEY_PATH`: If set, use API key at path
+- `RADIO_NAME`: Display name of radio in Cloudlog
+
+## Docker
+Build the docker image with  `docker build . -t cloudlog-rigctl-interface`.
+
+Run with
+
+```
+docker run \
+	   --env RIGCTL_HOST=172.17.0.1 \
+	   --env RIGCTL_PORT=4532 \
+	   --env CLOUDLOG_URL=https://log.tbspace.de \
+	   --env CLOUDLOG_KEY=p1fgZhGPbWMRaD4Iz5xm \
+	   --env RADIO_NAME=FT-991a \
+	   cloudlog-rigctl-interface
+```
+
+If running on the same machine as rigctld, you might not be able to connect to localhost due to docker's network isolation. Adding `--network host` to docker run options can get around this but there is a security tradeoff. Targeted access can be configured depending on your docker distribution.

--- a/config.php
+++ b/config.php
@@ -7,17 +7,19 @@
  *
  */
 
-// rigctl-specific configuration 
-$rigctl_host = "127.0.0.1";
-$rigctl_port = 4532;
+// rigctl-specific configuration
+$rigctl_host = $_ENV["RIGCTL_HOST"];
+$rigctl_port = $_ENV["RIGCTL_PORT"];
 
 // Cloudlog-specific parameters
-$cloudlog_url = "https://log.tbspace.de";
-$cloudlog_apikey = "p1fgZhGPbWMRaD4Iz5xm";
+$cloudlog_url = $_ENV["CLOUDLOG_URL"];
+$cloudlog_apikey = isset($_ENV['CLOUDLOG_KEY_PATH'])
+                 ? trim(file_get_contents($_ENV["CLOUDLOG_KEY_PATH"]))
+                 : $_ENV['CLOUDLOG_KEY'];
 
 // displayed in Cloudlogs Live QSO menu
-$radio_name = "FT-991a";
+$radio_name = $_ENV["RADIO_NAME"];
 
 // minimum update interval
-$interval = 1; 
+$interval = 1;
 


### PR DESCRIPTION
As discussed in #1.

Changes:
- `config.php` modified to used environment variables, with the option to specify cloudlog API key via a file (useful when using secret provisioning tools)
- Added Dockerfile
- Updated documentation to reflect the above

If the Dockerfile is useful, we may want to consider adding it to ghcr.io and/or Docker hub, which would enable us to remove the requirement to build the docker image in the docker-specific instructions. I can help with setting up GitHub actions to do that if required.